### PR TITLE
Fix generator to produce per-skill source isolation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,10 +12,10 @@
     {
       "name": "creating-pds-issues",
       "description": "Create GitHub issues in NASA-PDS repositories using organizational templates (bug reports, I&T bug reports, feature requests, tasks, vulnerabilities, release themes). Use when a user requests to create, file, or submit PDS issues.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/creating-pds-issues",
       "strict": false,
       "skills": [
-        "./skills/creating-pds-issues"
+        "."
       ],
       "keywords": [
         "github",
@@ -28,10 +28,10 @@
     {
       "name": "creating-pds-pull-requests",
       "description": "Create GitHub pull requests in NASA-PDS repositories with auto-detection of repo/branch, issue linking, reviewer assignment, and label management. Use when a user requests to create, open, submit, or make a pull request.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/creating-pds-pull-requests",
       "strict": false,
       "skills": [
-        "./skills/creating-pds-pull-requests"
+        "."
       ],
       "keywords": [
         "github",
@@ -44,10 +44,10 @@
     {
       "name": "generating-release-notes",
       "description": "Generate GitHub release notes from merged PRs and issues with automated categorization, breaking change detection, and optional upload via the gh CLI. Use when creating releases, publishing new versions, or documenting changes.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/generating-release-notes",
       "strict": false,
       "skills": [
-        "./skills/generating-release-notes"
+        "."
       ],
       "keywords": [
         "release-notes",
@@ -60,10 +60,10 @@
     {
       "name": "dependabot-alerts-exporting",
       "description": "Export GitHub Dependabot dependency vulnerability alerts for NASA-PDS repositories to JSON. Use when a user requests to export, fetch, or download Dependabot alerts, dependency vulnerability data, or CVE reports.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/dependabot-alerts-exporting",
       "strict": false,
       "skills": [
-        "./skills/dependabot-alerts-exporting"
+        "."
       ],
       "keywords": [
         "security",
@@ -76,10 +76,10 @@
     {
       "name": "dependabot-alerts-triaging",
       "description": "Analyze GitHub Dependabot dependency vulnerability alerts and suggest triage decisions (dismiss/fix/escalate) with explanations. Use when reviewing Dependabot alerts or triaging CVEs across NASA-PDS repositories.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/dependabot-alerts-triaging",
       "strict": false,
       "skills": [
-        "./skills/dependabot-alerts-triaging"
+        "."
       ],
       "keywords": [
         "security",
@@ -92,10 +92,10 @@
     {
       "name": "sonarcloud-security-exporting",
       "description": "Export SonarCloud security issues (vulnerabilities and hotspots) for NASA-PDS repositories to CSV or JSON. Use when a user requests to export, download, or fetch SonarCloud security data or vulnerability reports.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/sonarcloud-security-exporting",
       "strict": false,
       "skills": [
-        "./skills/sonarcloud-security-exporting"
+        "."
       ],
       "keywords": [
         "security",
@@ -108,10 +108,10 @@
     {
       "name": "sonarcloud-security-triaging",
       "description": "Analyze SonarCloud security issues and suggest triage decisions (SAFE/FIXED/wontfix/falsepositive) with explanations. Use when reviewing security issues or making triage decisions.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/sonarcloud-security-triaging",
       "strict": false,
       "skills": [
-        "./skills/sonarcloud-security-triaging"
+        "."
       ],
       "keywords": [
         "security",
@@ -124,10 +124,10 @@
     {
       "name": "sonarcloud-security-updating",
       "description": "Update SonarCloud security issues by applying triage decisions from JSON or CSV files. Use when bulk-updating SonarCloud with reviewed triage decisions or applying security review outcomes.",
-      "source": "./static/marketplace",
+      "source": "./static/marketplace/skills/sonarcloud-security-updating",
       "strict": false,
       "skills": [
-        "./skills/sonarcloud-security-updating"
+        "."
       ],
       "keywords": [
         "security",

--- a/src/conf/generate-marketplace.js
+++ b/src/conf/generate-marketplace.js
@@ -135,9 +135,9 @@ function toPlugin(entry, marketplaceSource) {
   };
 
   if (entry.type === "skill") {
-    plugin.source = marketplaceSource;
+    plugin.source = entry.source || `${marketplaceSource}/skills/${entry.name}`;
     plugin.strict = false;
-    plugin.skills = [`./skills/${entry.name}`];
+    plugin.skills = ["."];
   } else if (entry.type === "agent") {
     plugin.source = marketplaceSource;
     plugin.strict = false;


### PR DESCRIPTION
## Summary
- Fixes the root cause of #15 at the generator level — `generate-marketplace.js` now derives a per-skill isolated `source` path (`./static/marketplace/skills/<name>`) and sets `skills=['.']` for each plugin instead of pointing all plugins at the shared `./static/marketplace` root
- `registry.json` remains unchanged as the source of truth; no per-entry source override is needed since the generator handles the correct path automatically
- `npm run prebuild` output verified: all 8 plugins now have isolated source paths

## Why PR #16 wasn't enough
PR #16 manually patched `marketplace.json`, but `marketplace.json` is a **generated** file — running `npm run prebuild` would have reverted it back to the broken output. This PR fixes the generator itself so the correct output is durable.

## Test plan
- [ ] Run `npm run prebuild` and verify each plugin in `.claude-plugin/marketplace.json` has `source=./static/marketplace/skills/<name>` and `skills=['.']`
- [ ] Clear plugin cache: `rm -rf ~/.claude/plugins/cache/pds-agent-skills/`
- [ ] Install a single plugin: `/plugin install creating-pds-issues@pds-agent-skills` then `/reload-plugins`
- [ ] Verify only `creating-pds-issues:creating-pds-issues` appears, not all 8 skills

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
